### PR TITLE
Update __init__.py

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -4,6 +4,7 @@ from esphome.const import CONF_ID
 from esphome.core import coroutine_with_priority, CORE
 
 DEPENDENCIES = ['network', 'async_tcp']
+AUTO_LOAD = ['async_tcp']
 
 web_server_base_ns = cg.esphome_ns.namespace('web_server_base')
 WebServerBase = web_server_base_ns.class_('WebServerBase', cg.Component)


### PR DESCRIPTION
fix AUTO_LOAD of web_server_base to include ASYNC_TCP

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
